### PR TITLE
Terminal-safe redexdump output

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -144,7 +144,7 @@ redexdump_SOURCES = \
 	tools/common/DexCommon.cpp \
 	tools/common/Formatters.cpp
 
-redexdump_LDALL = libredex.la
+redexdump_LDADD = libredex.la
 
 #
 # redex: Python driver script

--- a/tools/redexdump/PrintUtil.cpp
+++ b/tools/redexdump/PrintUtil.cpp
@@ -12,6 +12,7 @@
 #include <cstdarg>
 
 bool clean = false;
+bool raw = false;
 
 void redump(const char* format, ...) {
   va_list va;

--- a/tools/redexdump/PrintUtil.h
+++ b/tools/redexdump/PrintUtil.h
@@ -12,6 +12,7 @@
 #include <stdint.h>
 
 extern bool clean;
+extern bool raw;
 
 void redump(const char* format, ...);
 void redump(uint32_t off, const char* format, ...);

--- a/tools/redexdump/RedexDump.cpp
+++ b/tools/redexdump/RedexDump.cpp
@@ -45,6 +45,7 @@ static const char ddump_usage_string[] =
     "-D, --ddebug=<addr>: disassemble debug info item at <addr>\n"
     "\nprinting options:\n"
     "--clean: does not print indexes or offsets making the output "
+    "--raw: print all bytes, even control characters "
     "usable for a diff\n";
 
 int main(int argc, char* argv[]) {
@@ -82,6 +83,7 @@ int main(int argc, char* argv[]) {
     { "debug", no_argument, nullptr, 'd' },
     { "ddebug", required_argument, nullptr, 'D' },
     { "clean", no_argument, (int*)&clean, 1 },
+    { "raw", no_argument, (int*)&raw, 1 },
     { "no-dump-map", no_argument, &no_dump_map, 1 },
     { "help", no_argument, nullptr, 'h' },
     { nullptr, 0, nullptr, 0 },


### PR DESCRIPTION
When dumping strings, translate MUTF-8 to UTF-8 and replace control characters with a placeholder; add --raw option to skip this work and restore old behavior
